### PR TITLE
update and delete implemented for all entities

### DIFF
--- a/documentation/issue-tickets/Delete-Genre.md
+++ b/documentation/issue-tickets/Delete-Genre.md
@@ -1,4 +1,4 @@
-# Delete an existing genre
+# Delete an existing genre CHECK
 
 ## Description
 This ticket requests the implementation of a route that allows the deletion of an existing genre.

--- a/documentation/issue-tickets/Delete-Song.md
+++ b/documentation/issue-tickets/Delete-Song.md
@@ -1,4 +1,4 @@
-# Delete an existing song
+# Delete an existing song CHECK
 
 ## Description
 This ticket requests the implementation of a route that allows the deletion of an existing song.

--- a/documentation/issue-tickets/Delete-an-Artist.md
+++ b/documentation/issue-tickets/Delete-an-Artist.md
@@ -1,4 +1,4 @@
-# Delete an existing artist
+# Delete an existing artist CHECK
 
 ## Description
 This ticket requests the implementation of a route that allows the deletion of an existing artist.

--- a/documentation/issue-tickets/Update-Genre.md
+++ b/documentation/issue-tickets/Update-Genre.md
@@ -1,4 +1,4 @@
-# Update an existing genre
+# Update an existing genre CHECK
 
 ## Description
 This ticket requests the implementation of a route that allows updating an existing genre.

--- a/documentation/issue-tickets/Update-Song.md
+++ b/documentation/issue-tickets/Update-Song.md
@@ -1,4 +1,4 @@
-# Update an existing song
+# Update an existing song CHECK
 
 ## Description
 This ticket requests the implementation of a route that allows updating an existing song.

--- a/documentation/issue-tickets/Update-an-Artist.md
+++ b/documentation/issue-tickets/Update-an-Artist.md
@@ -1,4 +1,4 @@
-# Update an existing artist
+# Update an existing artist CHECK
 
 ## Description
 This ticket requests the implementation of a route that allows updating an existing artist.

--- a/tunaapi/views/artist.py
+++ b/tunaapi/views/artist.py
@@ -34,3 +34,21 @@ class ArtistViewSet(ViewSet):
             serializer = ArtistSerializer(artist)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def destroy(self, request, pk=None):
+        # Delete an artist by ID
+            artist = Artist.objects.get(pk=pk)
+            artist.delete()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def update(self, request, pk=None):
+        # Update an existing artist
+        artist = Artist.objects.get(pk=pk)
+        artist.name = request.data["name"]
+        artist.age = request.data["age"]
+        artist.bio = request.data["bio"]
+        artist.save()
+
+        # Serialize the updated artist and return the response
+        serializer = ArtistSerializer(artist)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/tunaapi/views/genre.py
+++ b/tunaapi/views/genre.py
@@ -30,3 +30,19 @@ class GenreViewSet(ViewSet):
             serializer = GenreSerializer(genre)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def destroy(self, request, pk=None):
+        # Delete a genre by ID
+        genre = Genre.objects.get(pk=pk)
+        genre.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def update(self, request, pk=None):
+        # Update an existing genre
+        genre = Genre.objects.get(pk=pk)
+        genre.description = request.data["description"]
+        genre.save()
+
+        # Serialize the updated genre and return the response
+        serializer = GenreSerializer(genre)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/tunaapi/views/song.py
+++ b/tunaapi/views/song.py
@@ -34,3 +34,20 @@ class SongViewSet(ViewSet):
             serializer = self.SongSerializer(song)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def destroy(self, request, pk=None):
+        song = Song.objects.get(pk=pk)
+        song.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def update(self, request, pk=None):
+        song = Song.objects.get(pk=pk)
+        serializer = self.SongSerializer(song, data=request.data, partial=True)
+        if serializer.is_valid():
+            song.title = serializer.validated_data.get('title', song.title)
+            song.artist_id = serializer.validated_data.get('artist_id', song.artist_id)
+            song.album = serializer.validated_data.get('album', song.album)
+            song.length = serializer.validated_data.get('length', song.length)
+            song.save()
+            return Response(self.SongSerializer(song).data, status=status.HTTP_200_OK)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
This pull request introduces new functionality to support the deletion and updating of artists, genres, and songs in the `tunaapi` application, along with corresponding updates to the documentation. The most important changes include adding `destroy` and `update` methods to the views for these models and updating the related issue tickets to reflect the new functionality.

### Backend Functionality Added:

* **Artist Management (`tunaapi/views/artist.py`)**:
  - Added a `destroy` method to delete an artist by ID.
  - Added an `update` method to modify an artist's attributes (e.g., name, age, bio) and save the changes.

* **Genre Management (`tunaapi/views/genre.py`)**:
  - Added a `destroy` method to delete a genre by ID.
  - Added an `update` method to modify a genre's description and save the changes.

* **Song Management (`tunaapi/views/song.py`)**:
  - Added a `destroy` method to delete a song by ID.
  - Added an `update` method to modify a song's attributes (e.g., title, artist ID, album, length) using partial updates.

### Documentation Updates:

* **Delete Issue Tickets**:
  - Updated titles in `Delete-Genre.md`, `Delete-Song.md`, and `Delete-an-Artist.md` to include the word "CHECK" for clarity. [[1]](diffhunk://#diff-8c8ef7d1de9976607e74f866380d23586c74f35497e831835b9d7dc1fb01ab6dL1-R1) [[2]](diffhunk://#diff-9397fba3e8e2222fc6d1eb2f75197d2b13c22374db1123c9c7507bbe792fb69eL1-R1) [[3]](diffhunk://#diff-9cc590d37351b8b9d8bcecd7372a182aae28a02ce0a39b94c7dba9d132e64235L1-R1)

* **Update Issue Tickets**:
  - Updated titles in `Update-Genre.md`, `Update-Song.md`, and `Update-an-Artist.md` to include the word "CHECK" for clarity. [[1]](diffhunk://#diff-a5b0a1e5e79a0e9d21c91b896c0eac32f378a15243c1aa4b4f96cd5423625fb4L1-R1) [[2]](diffhunk://#diff-b66dd7993dc7f99ee772cc3931746ea1f79ae28605e289f814cb82bbce959e29L1-R1) [[3]](diffhunk://#diff-a32ced0a449107b539c2ae83e1c9f5c4761d0c553a3b0b864991ddbdf8450f9eL1-R1)