### PR TITLE
needed some filtering and needed to had an incorrect reverse relation…

### DIFF
--- a/tunaapi/models/__init__.py
+++ b/tunaapi/models/__init__.py
@@ -1,0 +1,3 @@
+from .artist import Artist
+from .genre import Genre, SongGenre
+from .song import Song

--- a/tunaapi/models/genre.py
+++ b/tunaapi/models/genre.py
@@ -11,9 +11,40 @@ class Genre(models.Model):
         verbose_name_plural = "Genres"
         ordering = ['description']
 
+class SongGenreManager(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset().select_related('genre_id', 'song_id')
+
+    def filter_by_genre(self, genre):
+        return self.filter(genre_id=genre)
+
+    def filter(self, *args, **kwargs):
+        if 'genre' in kwargs:
+            kwargs['genre_id'] = kwargs.pop('genre')
+        return super().filter(*args, **kwargs)
+
 class SongGenre(models.Model):
-    song_id = models.ForeignKey('Song', on_delete=models.CASCADE)
-    genre_id = models.ForeignKey('Genre', on_delete=models.CASCADE)
+    song_id = models.ForeignKey('Song', on_delete=models.CASCADE, related_name='song_genres')
+    genre_id = models.ForeignKey('Genre', on_delete=models.CASCADE, related_name='song_genres')
+    genre = models.ForeignKey('Genre', on_delete=models.CASCADE, related_name='proxy_genre', db_column='genre_id')
+
+    objects = SongGenreManager()
 
     class Meta:
         db_table = 'song_genre'
+
+    @property
+    def song(self):
+        return self.song_id
+
+    @song.setter
+    def song(self, value):
+        self.song_id = value
+
+    @property
+    def genre(self):
+        return self.genre_id
+
+    @genre.setter
+    def genre(self, value):
+        self.genre_id = value

--- a/tunaapi/models/song.py
+++ b/tunaapi/models/song.py
@@ -14,3 +14,13 @@ class Song(models.Model):
         verbose_name = "Song"
         verbose_name_plural = "Songs"
         ordering = ['title']
+
+    @property
+    def artist(self):
+        return self.artist_id
+
+    @artist.setter
+    def artist(self, value):
+        self.artist_id = value
+
+        

--- a/tunaapi/views/genre.py
+++ b/tunaapi/views/genre.py
@@ -19,7 +19,7 @@ class GenreViewSet(ViewSet):
         genre = Genre.objects.get(pk=pk)
 
         # Fetch songs associated with the genre using the SongGenre table
-        song_genres = genre.songgenre_set.all()
+        song_genres = genre.song_genres.all()
         songs = [
             {
                 "id": sg.song_id.id,

--- a/tunaapi/views/song.py
+++ b/tunaapi/views/song.py
@@ -32,7 +32,7 @@ class SongViewSet(ViewSet):
         }
 
         # Fetch associated genres using the SongGenre table
-        song_genres = song.songgenre_set.all()
+        song_genres = song.song_genres.all()
         genres = [
             {
                 "id": sg.genre_id.id,


### PR DESCRIPTION
This pull request introduces several changes to improve the organization and functionality of the `tunaapi` models and their usage in views. Key updates include adding related names to model relationships, introducing a custom manager for the `SongGenre` model, and updating the views to use the new relationships. These changes enhance code readability, maintainability, and performance by leveraging Django's ORM features.

### Model Enhancements:

* [`tunaapi/models/__init__.py`](diffhunk://#diff-cdee7f3eb688a3f1259250b1035e8986045961f821939b2e072480e7d885c73dR1-R3): Imported `Artist`, `Genre`, `Song`, and `SongGenre` models to make them accessible from the `models` package.
* `tunaapi/models/genre.py`: 
  - Added a custom manager, `SongGenreManager`, to the `SongGenre` model for optimized queries and filtering by genre.
  - Updated `song_id` and `genre_id` fields in `SongGenre` to include `related_name` attributes, and added a new `genre` field with a proxy relationship.
  - Introduced `@property` methods for `song` and `genre` in `SongGenre` to simplify access and assignment.
* [`tunaapi/models/song.py`](diffhunk://#diff-46be5d16d33603a72a002a4fdeb505d81324faae2ddd1006b98209ff06d63e56R17-R26): Added `@property` methods for `artist` in the `Song` model to allow easier access and assignment of the `artist_id` field.

### View Updates:

* [`tunaapi/views/genre.py`](diffhunk://#diff-b0afd34346b9fc682014bbfdf61ebf7347c6cd3ba2eb470a67fd7b4aaaa6654eL22-R22): Updated the `retrieve` method to use the `song_genres` related name for fetching songs associated with a genre.
* [`tunaapi/views/song.py`](diffhunk://#diff-b8cfcfa13eef2d4a871947ce0370bd84f3264c1068a95e3136063e02b039d9aaL35-R35): Updated the `retrieve` method to use the `song_genres` related name for fetching genres associated with a song.…ship that has been resolved